### PR TITLE
Add comprehensive xUnit test suite for Radiomics.Net

### DIFF
--- a/Radiomics.Net.Tests/FeatureCalculatorTests.cs
+++ b/Radiomics.Net.Tests/FeatureCalculatorTests.cs
@@ -1,0 +1,105 @@
+using Radiomics.Net.Exceptions;
+using Radiomics.Net.Features;
+using Radiomics.Net.ImageProcess;
+
+namespace Radiomics.Net.Tests;
+
+public class FeatureCalculatorTests
+{
+    private const double Tolerance = 1e-6;
+
+    [Fact]
+    public void Calculate_ComputesEnabledFeaturesAndStoresInDicom()
+    {
+        var (image, mask, _, parameters) = TestDataFactory.CreateStandardImageData();
+        parameters.Preprocess = new[] { "Normalize", "Resample", "RangeFilter" };
+        parameters.NormalizeScale = 1d;
+        parameters.ResamplingFactorXYZ = new[] { 1d, 1d, 1d };
+        parameters.RangeMax = 100d;
+        parameters.RangeMin = -100d;
+        parameters.UseFixedBinNumber = true;
+        parameters.NBins = 9;
+        parameters.Interpolation2D = 0;
+        parameters.MaskPartialVolumeThreshold = 0.5;
+        parameters.Force2D = true;
+
+        var datasets = TestDataFactory.CreateFeatureCalculatorDicoms(image, mask, parameters);
+
+        var processed = PrepareForExpectations(image, mask, parameters);
+        var firstOrderExpectations = FirstOrderExpectedCalculator.Compute(processed.Image, processed.Mask, processed.Discrete, parameters);
+        var glcmFeatures = new GLCMFeatures(processed.Image, processed.Mask, processed.Discrete, parameters);
+        var glcmExpectations = GlcmExpectedCalculator.Compute(glcmFeatures);
+
+        var result = FeatureCalculator.Calclate(datasets);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal((int)Errors.OK, result.ErrorCode);
+
+        var dataset = datasets[0];
+        foreach (var kvp in firstOrderExpectations)
+        {
+            var tag = PrivateDicomTag.GetPrivateDicomTagByName(kvp.Key.ToString());
+            Assert.True(dataset.TryGetValue<double>(tag, 0, out var actual));
+            Assert.Equal(kvp.Value, actual, Tolerance);
+        }
+
+        foreach (var kvp in glcmExpectations)
+        {
+            var tag = PrivateDicomTag.GetPrivateDicomTagByName(kvp.Key.ToString());
+            Assert.True(dataset.TryGetValue<double>(tag, 0, out var actual));
+            if (double.IsNaN(kvp.Value))
+            {
+                Assert.True(double.IsNaN(actual));
+            }
+            else
+            {
+                Assert.Equal(kvp.Value, actual, Tolerance);
+            }
+        }
+    }
+
+    private static (ImagePlus Image, ImagePlus Mask, ImagePlus Discrete) PrepareForExpectations(ImagePlus sourceImage, ImagePlus sourceMask, CaculateParams parameters)
+    {
+        ImagePlus image = sourceImage;
+        ImagePlus mask = sourceMask;
+
+        if (parameters.Preprocess.Contains("Normalize"))
+        {
+            image = ImagePreprocessing.Normalize(image, mask, parameters);
+        }
+
+        if (parameters.Preprocess.Contains("Resample") && parameters.ResamplingFactorXYZ != null)
+        {
+            var resampled = ImagePreprocessing.Resample(image, mask, parameters.ResamplingFactorXYZ, parameters);
+            image = resampled[0] ?? image;
+            mask = resampled[1] ?? mask;
+        }
+
+        if (parameters.Preprocess.Contains("RangeFilter"))
+        {
+            mask = ImagePreprocessing.RangeFiltering(image, mask, (int)parameters.Label, parameters.RangeMax, parameters.RangeMin);
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.WaveFilterName))
+        {
+            image = ImagePreprocessing.FwtTransform(image, parameters);
+        }
+
+        var cropped = ImagePreprocessing.Crop(image, mask, parameters);
+        image = cropped[0] ?? image;
+        mask = cropped[1] ?? mask;
+
+        ImagePlus discrete;
+        if (parameters.UseFixedBinNumber)
+        {
+            discrete = Utils.Discrete(image, mask, (int)parameters.Label, parameters.NBins);
+        }
+        else
+        {
+            discrete = Utils.DiscreteByBinWidth(image, mask, (int)parameters.Label, parameters);
+            parameters.NBins = Utils.GetNumOfBinsByMax(discrete, mask, (int)parameters.Label);
+        }
+
+        return (image, mask, discrete);
+    }
+}

--- a/Radiomics.Net.Tests/FirstOrderExpectedCalculator.cs
+++ b/Radiomics.Net.Tests/FirstOrderExpectedCalculator.cs
@@ -1,0 +1,211 @@
+using MathNet.Numerics.Statistics;
+using Radiomics.Net.Features;
+using Radiomics.Net.ImageProcess;
+
+namespace Radiomics.Net.Tests;
+
+internal static class FirstOrderExpectedCalculator
+{
+    public static IReadOnlyDictionary<FirstOrderFeatureType, double> Compute(ImagePlus image, ImagePlus mask, ImagePlus discrete, CaculateParams parameters)
+    {
+        var voxels = Utils.GetVoxels(image, mask, (int)parameters.Label);
+        var discreteVoxels = Utils.GetVoxels(discrete, mask, (int)parameters.Label);
+        var histogram = Utils.GetHistogram(discreteVoxels)!;
+
+        var volume = image.PixelWidth * image.PixelHeight * image.PixelDepth;
+        var mean = Statistics.Mean(voxels);
+        var variance = CalculateVariance(voxels, mean);
+        var stdDev = Math.Sqrt(variance);
+        var energy = voxels.Sum(v => Math.Pow(v + parameters.DensityShift, 2));
+        var sorted = voxels;
+        Array.Sort(sorted);
+
+        var percentile10 = GetPercentile(sorted, 10);
+        var percentile25 = GetPercentile(sorted, 25);
+        var percentile75 = GetPercentile(sorted, 75);
+        var percentile90 = GetPercentile(sorted, 90);
+
+        var robustRange = sorted.Where(v => v >= percentile10 && v <= percentile90).ToArray();
+        var robustMean = robustRange.Length > 0 ? Statistics.Mean(robustRange) : double.NaN;
+        var robustMad = robustRange.Length > 0
+            ? robustRange.Sum(v => Math.Abs(v - robustMean)) / robustRange.Length
+            : double.NaN;
+
+        var entropy = CalculateEntropy(histogram, voxels.Length);
+        var uniformity = CalculateUniformity(histogram, voxels.Length);
+        var peak = CalculatePeak(image, mask, (int)parameters.Label);
+
+        return new Dictionary<FirstOrderFeatureType, double>
+        {
+            [FirstOrderFeatureType.Mean] = mean,
+            [FirstOrderFeatureType.Variance] = variance,
+            [FirstOrderFeatureType.Skewness] = CalculateSkewness(voxels, mean),
+            [FirstOrderFeatureType.Kurtosis] = CalculateKurtosis(voxels, mean),
+            [FirstOrderFeatureType.Median] = GetMedian(sorted),
+            [FirstOrderFeatureType.Minimum] = sorted.First(),
+            [FirstOrderFeatureType.Percentile10] = percentile10,
+            [FirstOrderFeatureType.Percentile90] = percentile90,
+            [FirstOrderFeatureType.Maximum] = sorted.Last(),
+            [FirstOrderFeatureType.Peak] = peak,
+            [FirstOrderFeatureType.Interquartile] = percentile75 - percentile25,
+            [FirstOrderFeatureType.Range] = sorted.Last() - sorted.First(),
+            [FirstOrderFeatureType.MeanAbsoluteDeviation] = voxels.Sum(v => Math.Abs(v - mean)) / voxels.Length,
+            [FirstOrderFeatureType.RobustMeanAbsoluteDeviation] = robustMad,
+            [FirstOrderFeatureType.Energy] = energy,
+            [FirstOrderFeatureType.RootMeanSquared] = Math.Sqrt(energy / voxels.Length),
+            [FirstOrderFeatureType.TotalEnergy] = energy * volume,
+            [FirstOrderFeatureType.StandardDeviation] = stdDev,
+            [FirstOrderFeatureType.Entropy] = entropy,
+            [FirstOrderFeatureType.Uniformity] = uniformity
+        };
+    }
+
+    private static double CalculateVariance(double[] voxels, double mean)
+    {
+        double sumsq = 0;
+        foreach (var v in voxels)
+        {
+            sumsq += Math.Pow(v - mean, 2);
+        }
+        return sumsq / voxels.Length;
+    }
+
+    private static double CalculateSkewness(double[] voxels, double mean)
+    {
+        double sum2 = 0;
+        double sum3 = 0;
+        foreach (var v in voxels)
+        {
+            var diff = v - mean;
+            sum2 += Math.Pow(diff, 2);
+            sum3 += Math.Pow(diff, 3);
+        }
+        var n = voxels.Length;
+        return (sum3 / n) / Math.Pow(Math.Sqrt(sum2 / n), 3);
+    }
+
+    private static double CalculateKurtosis(double[] voxels, double mean)
+    {
+        double sum2 = 0;
+        double sum4 = 0;
+        foreach (var v in voxels)
+        {
+            var diff = v - mean;
+            sum2 += Math.Pow(diff, 2);
+            sum4 += Math.Pow(diff, 4);
+        }
+        var n = voxels.Length;
+        return (sum4 / n) / Math.Pow(sum2 / n, 2);
+    }
+
+    private static double GetMedian(double[] sorted)
+    {
+        if (sorted.Length % 2 == 0)
+        {
+            var mid = sorted.Length / 2;
+            return (sorted[mid] + sorted[mid - 1]) / 2d;
+        }
+        return sorted[sorted.Length / 2];
+    }
+
+    private static double GetPercentile(double[] sorted, int percentile)
+    {
+        var index = (int)Math.Floor(percentile / 100d * sorted.Length);
+        index = Math.Clamp(index, 0, sorted.Length - 1);
+        return sorted[index];
+    }
+
+    private static double CalculateEntropy(int[] histogram, int total)
+    {
+        double entropy = 0;
+        foreach (var count in histogram)
+        {
+            if (count <= 0)
+            {
+                continue;
+            }
+            var p = count / (double)total;
+            entropy -= p * (Math.Log(p) / Math.Log(2d));
+        }
+        return entropy;
+    }
+
+    private static double CalculateUniformity(int[] histogram, int total)
+    {
+        double uniformity = 0;
+        foreach (var count in histogram)
+        {
+            if (count <= 0)
+            {
+                continue;
+            }
+            var p = count / (double)total;
+            uniformity += Math.Pow(p, 2);
+        }
+        return uniformity;
+    }
+
+    private static double CalculatePeak(ImagePlus image, ImagePlus mask, int label)
+    {
+        double peak = double.MinValue;
+        for (int z = 0; z < image.Slice; z++)
+        {
+            for (int y = 0; y < image.Height; y++)
+            {
+                for (int x = 0; x < image.Width; x++)
+                {
+                    if ((int)mask.GetXYZ(x, y, z) != label)
+                    {
+                        continue;
+                    }
+
+                    var neighbours = new List<double>();
+                    for (int nz = z - 1; nz <= z + 1; nz++)
+                    {
+                        if (nz < 0 || nz >= image.Slice)
+                        {
+                            continue;
+                        }
+                        for (int ny = y - 1; ny <= y + 1; ny++)
+                        {
+                            if (ny < 0 || ny >= image.Height)
+                            {
+                                continue;
+                            }
+                            for (int nx = x - 1; nx <= x + 1; nx++)
+                            {
+                                if (nx < 0 || nx >= image.Width)
+                                {
+                                    continue;
+                                }
+                                var distance = Math.Sqrt(Math.Pow(nx - x, 2) + Math.Pow(ny - y, 2) + Math.Pow(nz - z, 2));
+                                if (distance == 0 || distance > 1)
+                                {
+                                    continue;
+                                }
+                                neighbours.Add(image.GetXYZ(nx, ny, nz));
+                            }
+                        }
+                    }
+
+                    double candidate;
+                    if (neighbours.Count == 0)
+                    {
+                        candidate = image.GetXYZ(x, y, z);
+                    }
+                    else
+                    {
+                        candidate = neighbours.Average();
+                    }
+
+                    if (candidate > peak)
+                    {
+                        peak = candidate;
+                    }
+                }
+            }
+        }
+
+        return peak == double.MinValue ? double.NaN : peak;
+    }
+}

--- a/Radiomics.Net.Tests/FirstOrderFeaturesTests.cs
+++ b/Radiomics.Net.Tests/FirstOrderFeaturesTests.cs
@@ -1,0 +1,31 @@
+using Radiomics.Net.Features;
+using Radiomics.Net.ImageProcess;
+
+namespace Radiomics.Net.Tests;
+
+public class FirstOrderFeaturesTests
+{
+    private const double Tolerance = 1e-6;
+
+    public static IEnumerable<object[]> FeatureExpectations()
+    {
+        var (image, mask, discrete, parameters) = TestDataFactory.CreateStandardImageData();
+        var expectations = FirstOrderExpectedCalculator.Compute(image, mask, discrete, parameters);
+        foreach (var kvp in expectations)
+        {
+            yield return new object[] { kvp.Key, kvp.Value };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(FeatureExpectations))]
+    public void Calculate_ReturnsExpectedValues(FirstOrderFeatureType featureType, double expected)
+    {
+        var (image, mask, discrete, parameters) = TestDataFactory.CreateStandardImageData();
+        var features = new FirstOrderFeatures(image, mask, discrete, parameters);
+
+        var actual = features.Calculate(featureType);
+
+        Assert.Equal(expected, actual, Tolerance);
+    }
+}

--- a/Radiomics.Net.Tests/GlcmExpectedCalculator.cs
+++ b/Radiomics.Net.Tests/GlcmExpectedCalculator.cs
@@ -1,0 +1,504 @@
+using MathNet.Numerics.LinearAlgebra;
+using Radiomics.Net.Features;
+using Radiomics.Net.ImageProcess;
+using System.Reflection;
+
+namespace Radiomics.Net.Tests;
+
+internal static class GlcmExpectedCalculator
+{
+    public static IReadOnlyDictionary<GLCMFeatureType, double> Compute(GLCMFeatures features)
+    {
+        var glcmField = typeof(GLCMFeatures).GetField("glcm", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Unable to access GLCM matrices.");
+        var glcm = (Dictionary<int, double[][]>)glcmField.GetValue(features)!;
+        var nBinsField = typeof(GLCMFeatures).GetField("nBins", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Unable to access nBins.");
+        var nBins = (int)nBinsField.GetValue(features)!;
+        var eps = Utils.GetDoubleUlp(1.0);
+
+        var matrices = glcm.OrderBy(kvp => kvp.Key)
+            .Select(kvp => new KeyValuePair<int, GlcmDerivedData?>(kvp.Key, kvp.Value == null ? null : ComputeDerivedData(kvp.Value, nBins)))
+            .ToList();
+
+        return Enum.GetValues<GLCMFeatureType>().ToDictionary(
+            feature => feature,
+            feature => feature switch
+            {
+                GLCMFeatureType.MaximumProbability => Average(matrices, data => GetMaximum(data.Matrix)),
+                GLCMFeatureType.JointAverage => Average(matrices, data => GetJointAverage(data.Matrix)),
+                GLCMFeatureType.SumSquares => Average(matrices, data => GetSumSquares(data.Matrix)),
+                GLCMFeatureType.JointEntropy => Average(matrices, data => GetJointEntropy(data.Matrix, eps)),
+                GLCMFeatureType.JointEnergy => Average(matrices, data => GetJointEnergy(data.Matrix)),
+                GLCMFeatureType.DifferenceAverage => Average(matrices, data => GetDifferenceAverage(data.PxSubY)),
+                GLCMFeatureType.DifferenceVariance => Average(matrices, data => GetDifferenceVariance(data.PxSubY)),
+                GLCMFeatureType.DifferenceEntropy => Average(matrices, data => GetDifferenceEntropy(data.PxSubY, eps)),
+                GLCMFeatureType.SumAverage => Average(matrices, data => GetSumAverage(data.PxAddY)),
+                GLCMFeatureType.SumVariance => Average(matrices, data => GetSumVariance(data.PxAddY)),
+                GLCMFeatureType.SumEntropy => Average(matrices, data => GetSumEntropy(data.PxAddY, eps)),
+                GLCMFeatureType.Contrast => Average(matrices, data => GetContrast(data.Matrix)),
+                GLCMFeatureType.InverseDifference => Average(matrices, data => GetInverseDifference(data.PxSubY)),
+                GLCMFeatureType.NormalizedInverseDifference => Average(matrices, data => GetNormalisedInverseDifference(data.PxSubY, nBins)),
+                GLCMFeatureType.InverseDifferenceMoment => Average(matrices, data => GetInverseDifferenceMoment(data.Matrix)),
+                GLCMFeatureType.NormalizedInverseDifferenceMoment => Average(matrices, data => GetNormalisedInverseDifferenceMoment(data.Matrix, nBins)),
+                GLCMFeatureType.InverseVariance => Average(matrices, data => GetInverseVariance(data.PxSubY)),
+                GLCMFeatureType.Correlation => Average(matrices, data => GetCorrelation(data)),
+                GLCMFeatureType.Autocorrection => Average(matrices, data => GetAutocorrelation(data.Matrix)),
+                GLCMFeatureType.ClusterTendency => Average(matrices, data => GetClusterMoment(data, 2)),
+                GLCMFeatureType.ClusterShade => Average(matrices, data => GetClusterMoment(data, 3)),
+                GLCMFeatureType.ClusterProminence => Average(matrices, data => GetClusterMoment(data, 4)),
+                GLCMFeatureType.InformationalMeasureOfCorrelation1 => Average(matrices, data => GetImc1(data, eps)),
+                GLCMFeatureType.InformationalMeasureOfCorrelation2 => Average(matrices, data => GetImc2(data, eps)),
+                GLCMFeatureType.MCC => Average(matrices, data => GetMcc(data)),
+                _ => 0d
+            });
+    }
+
+    private static double Average(IReadOnlyList<KeyValuePair<int, GlcmDerivedData?>> matrices, Func<GlcmDerivedData, double> selector)
+    {
+        if (matrices.Count == 0)
+        {
+            return 0d;
+        }
+
+        double sum = 0;
+        foreach (var entry in matrices)
+        {
+            if (entry.Value is { } data)
+            {
+                sum += selector(data);
+            }
+        }
+        return sum / matrices.Count;
+    }
+
+    private static GlcmDerivedData ComputeDerivedData(double[][] matrix, int nBins)
+    {
+        var px = new double[nBins];
+        var py = new double[nBins];
+        for (int i = 0; i < nBins; i++)
+        {
+            for (int j = 0; j < nBins; j++)
+            {
+                var value = matrix[i][j];
+                px[i] += value;
+                py[j] += value;
+            }
+        }
+
+        double meanX = 0;
+        double meanY = 0;
+        for (int i = 0; i < nBins; i++)
+        {
+            meanX += (i + 1) * px[i];
+            meanY += (i + 1) * py[i];
+        }
+
+        double stdDevX = 0;
+        double stdDevY = 0;
+        for (int i = 0; i < nBins; i++)
+        {
+            stdDevX += Math.Pow((i + 1) - meanX, 2) * px[i];
+            stdDevY += Math.Pow((i + 1) - meanY, 2) * py[i];
+        }
+        stdDevX = Math.Sqrt(stdDevX);
+        stdDevY = Math.Sqrt(stdDevY);
+
+        var pxAddY = new double[(nBins * 2) - 1];
+        for (int k = 2; k <= nBins * 2; k++)
+        {
+            for (int i = 1; i <= nBins; i++)
+            {
+                for (int j = 1; j <= nBins; j++)
+                {
+                    if (k == i + j)
+                    {
+                        pxAddY[k - 2] += matrix[i - 1][j - 1];
+                    }
+                }
+            }
+        }
+
+        var pxSubY = new double[nBins];
+        for (int k = 0; k < nBins; k++)
+        {
+            for (int i = 1; i <= nBins; i++)
+            {
+                for (int j = 1; j <= nBins; j++)
+                {
+                    if (k == Math.Abs(i - j))
+                    {
+                        pxSubY[k] += matrix[i - 1][j - 1];
+                    }
+                }
+            }
+        }
+
+        return new GlcmDerivedData(matrix, px, py, pxAddY, pxSubY, meanX, meanY, stdDevX, stdDevY);
+    }
+
+    private static double GetMaximum(double[][] matrix)
+    {
+        double max = 0;
+        foreach (var row in matrix)
+        {
+            foreach (var value in row)
+            {
+                if (value > max)
+                {
+                    max = value;
+                }
+            }
+        }
+        return max;
+    }
+
+    private static double GetJointAverage(double[][] matrix)
+    {
+        double result = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                result += matrix[i][j] * (i + 1);
+            }
+        }
+        return result;
+    }
+
+    private static double GetSumSquares(double[][] matrix)
+    {
+        var mean = GetJointAverage(matrix);
+        double result = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                result += Math.Pow((i + 1) - mean, 2) * matrix[i][j];
+            }
+        }
+        return result;
+    }
+
+    private static double GetJointEntropy(double[][] matrix, double eps)
+    {
+        double entropy = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                var value = matrix[i][j];
+                if (value > 0)
+                {
+                    entropy -= value * (Math.Log(value + eps) / Math.Log(2d));
+                }
+            }
+        }
+        return entropy;
+    }
+
+    private static double GetJointEnergy(double[][] matrix)
+    {
+        double energy = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                var value = matrix[i][j];
+                energy += value * value;
+            }
+        }
+        return energy;
+    }
+
+    private static double GetDifferenceAverage(double[] pxSubY)
+    {
+        double result = 0;
+        for (int k = 0; k < pxSubY.Length; k++)
+        {
+            result += pxSubY[k] * k;
+        }
+        return result;
+    }
+
+    private static double GetDifferenceVariance(double[] pxSubY)
+    {
+        var mean = GetDifferenceAverage(pxSubY);
+        double result = 0;
+        for (int k = 0; k < pxSubY.Length; k++)
+        {
+            result += Math.Pow(k - mean, 2) * pxSubY[k];
+        }
+        return result;
+    }
+
+    private static double GetDifferenceEntropy(double[] pxSubY, double eps)
+    {
+        double result = 0;
+        for (int k = 0; k < pxSubY.Length; k++)
+        {
+            var value = pxSubY[k];
+            if (value > 0)
+            {
+                result -= value * (Math.Log(value + eps) / Math.Log(2d));
+            }
+        }
+        return result;
+    }
+
+    private static double GetSumAverage(double[] pxAddY)
+    {
+        double result = 0;
+        for (int k = 0; k < pxAddY.Length; k++)
+        {
+            result += pxAddY[k] * (k + 2);
+        }
+        return result;
+    }
+
+    private static double GetSumVariance(double[] pxAddY)
+    {
+        var mean = GetSumAverage(pxAddY);
+        double result = 0;
+        for (int k = 0; k < pxAddY.Length; k++)
+        {
+            result += Math.Pow((k + 2) - mean, 2) * pxAddY[k];
+        }
+        return result;
+    }
+
+    private static double GetSumEntropy(double[] pxAddY, double eps)
+    {
+        double result = 0;
+        for (int k = 0; k < pxAddY.Length; k++)
+        {
+            var value = pxAddY[k];
+            if (value > 0)
+            {
+                result -= value * (Math.Log(value + eps) / Math.Log(2d));
+            }
+        }
+        return result;
+    }
+
+    private static double GetContrast(double[][] matrix)
+    {
+        double result = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                result += Math.Pow(i - j, 2) * matrix[i][j];
+            }
+        }
+        return result;
+    }
+
+    private static double GetInverseDifference(double[] pxSubY)
+    {
+        double result = 0;
+        for (int k = 0; k < pxSubY.Length; k++)
+        {
+            result += pxSubY[k] / (1d + k);
+        }
+        return result;
+    }
+
+    private static double GetNormalisedInverseDifference(double[] pxSubY, int nBins)
+    {
+        double result = 0;
+        for (int k = 0; k < pxSubY.Length; k++)
+        {
+            result += pxSubY[k] / (1d + k / (double)nBins);
+        }
+        return result;
+    }
+
+    private static double GetInverseDifferenceMoment(double[][] matrix)
+    {
+        double result = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                result += matrix[i][j] / (1d + Math.Pow(i - j, 2));
+            }
+        }
+        return result;
+    }
+
+    private static double GetNormalisedInverseDifferenceMoment(double[][] matrix, int nBins)
+    {
+        double result = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                result += matrix[i][j] / (1d + (Math.Pow(i - j, 2) / Math.Pow(nBins, 2)));
+            }
+        }
+        return result;
+    }
+
+    private static double GetInverseVariance(double[] pxSubY)
+    {
+        double result = 0;
+        for (int k = 1; k < pxSubY.Length; k++)
+        {
+            if (k == 0)
+            {
+                continue;
+            }
+            result += pxSubY[k] / (k * k);
+        }
+        return result;
+    }
+
+    private static double GetCorrelation(GlcmDerivedData data)
+    {
+        var matrix = data.Matrix;
+        double numerator = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                numerator += ((i + 1) - data.MeanX) * ((j + 1) - data.MeanY) * matrix[i][j];
+            }
+        }
+        if (data.StdDevX == 0 || data.StdDevY == 0)
+        {
+            return double.NaN;
+        }
+        return (1d / (data.StdDevX * data.StdDevY)) * numerator;
+    }
+
+    private static double GetAutocorrelation(double[][] matrix)
+    {
+        double result = 0;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                result += matrix[i][j] * (i + 1) * (j + 1);
+            }
+        }
+        return result;
+    }
+
+    private static double GetClusterMoment(GlcmDerivedData data, int order)
+    {
+        double result = 0;
+        var matrix = data.Matrix;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                result += Math.Pow((i + 1) + (j + 1) - data.MeanX - data.MeanY, order) * matrix[i][j];
+            }
+        }
+        return result;
+    }
+
+    private static double GetImc1(GlcmDerivedData data, double eps)
+    {
+        double hx = 0;
+        double hxy = 0;
+        double hxy1 = 0;
+        var matrix = data.Matrix;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            if (data.Px[i] > 0)
+            {
+                hx -= data.Px[i] * (Math.Log(data.Px[i] + eps) / Math.Log(2d));
+            }
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                var value = matrix[i][j];
+                if (value > 0)
+                {
+                    hxy -= value * (Math.Log(value + eps) / Math.Log(2d));
+                }
+                hxy1 -= value * (Math.Log((data.Px[i] * data.Py[j]) + eps) / Math.Log(2d));
+            }
+        }
+        return hx == 0 ? double.NaN : (hxy - hxy1) / hx;
+    }
+
+    private static double GetImc2(GlcmDerivedData data, double eps)
+    {
+        double hxy = 0;
+        double hxy2 = 0;
+        var matrix = data.Matrix;
+        for (int i = 0; i < matrix.Length; i++)
+        {
+            for (int j = 0; j < matrix[i].Length; j++)
+            {
+                var value = matrix[i][j];
+                if (value > 0)
+                {
+                    hxy -= value * (Math.Log(value + eps) / Math.Log(2d));
+                }
+                var product = data.Px[i] * data.Py[j];
+                hxy2 -= product * (Math.Log(product + eps) / Math.Log(2d));
+            }
+        }
+        var exponent = -2d * (hxy2 - hxy);
+        var inner = 1d - Math.Exp(exponent);
+        return double.IsNaN(inner) || inner < 0 ? double.NaN : Math.Sqrt(inner);
+    }
+
+    private static double GetMcc(GlcmDerivedData data)
+    {
+        var matrix = data.Matrix;
+        var nBins = matrix.Length;
+        var glcmMatrix = Matrix<double>.Build.Dense(nBins, nBins, Utils.Convert2DToArray(matrix));
+        var pxMatrix = Matrix<double>.Build.Dense(nBins, 1, data.Px);
+        for (int i = 1; i < nBins; i++)
+        {
+            pxMatrix = pxMatrix.InsertColumn(pxMatrix.ColumnCount, pxMatrix.Column(0));
+        }
+
+        var py = data.Py;
+        var qMatrix = (glcmMatrix.SubMatrix(0, nBins, 0, 1) * glcmMatrix.SubMatrix(0, 1, 0, nBins))
+            .PointwiseDivide(pxMatrix * py[0] + Utils.GetDoubleUlp(1.0));
+        for (int i = 1; i < nBins; i++)
+        {
+            qMatrix += (glcmMatrix.SubMatrix(0, nBins, i, 1) * glcmMatrix.SubMatrix(i, 1, 0, nBins))
+                .PointwiseDivide(pxMatrix * py[i] + Utils.GetDoubleUlp(1.0));
+        }
+
+        var eigenValues = qMatrix.Evd().EigenValues.Map(c => c.Real).ToArray();
+        Array.Sort(eigenValues);
+        if (eigenValues.Length < 2)
+        {
+            return 1d;
+        }
+        return Math.Sqrt(Math.Max(0d, eigenValues[^2]));
+    }
+
+    private sealed class GlcmDerivedData
+    {
+        public GlcmDerivedData(double[][] matrix, double[] px, double[] py, double[] pxAddY, double[] pxSubY, double meanX, double meanY, double stdDevX, double stdDevY)
+        {
+            Matrix = matrix;
+            Px = px;
+            Py = py;
+            PxAddY = pxAddY;
+            PxSubY = pxSubY;
+            MeanX = meanX;
+            MeanY = meanY;
+            StdDevX = stdDevX;
+            StdDevY = stdDevY;
+        }
+
+        public double[][] Matrix { get; }
+        public double[] Px { get; }
+        public double[] Py { get; }
+        public double[] PxAddY { get; }
+        public double[] PxSubY { get; }
+        public double MeanX { get; }
+        public double MeanY { get; }
+        public double StdDevX { get; }
+        public double StdDevY { get; }
+    }
+}

--- a/Radiomics.Net.Tests/GlcmFeaturesTests.cs
+++ b/Radiomics.Net.Tests/GlcmFeaturesTests.cs
@@ -1,0 +1,38 @@
+using Radiomics.Net.Features;
+
+namespace Radiomics.Net.Tests;
+
+public class GlcmFeaturesTests
+{
+    private const double Tolerance = 1e-6;
+
+    public static IEnumerable<object[]> FeatureExpectations()
+    {
+        var (image, mask, discrete, parameters) = TestDataFactory.CreateStandardImageData();
+        var glcmFeatures = new GLCMFeatures(image, mask, discrete, parameters);
+        var expectations = GlcmExpectedCalculator.Compute(glcmFeatures);
+        foreach (var kvp in expectations)
+        {
+            yield return new object[] { kvp.Key, kvp.Value };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(FeatureExpectations))]
+    public void Calculate_ReturnsExpectedValues(GLCMFeatureType featureType, double expected)
+    {
+        var (image, mask, discrete, parameters) = TestDataFactory.CreateStandardImageData();
+        var features = new GLCMFeatures(image, mask, discrete, parameters);
+
+        var actual = features.Calculate(featureType);
+
+        if (double.IsNaN(expected))
+        {
+            Assert.True(double.IsNaN(actual));
+        }
+        else
+        {
+            Assert.Equal(expected, actual, Tolerance);
+        }
+    }
+}

--- a/Radiomics.Net.Tests/GlobalUsings.cs
+++ b/Radiomics.Net.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Radiomics.Net.Tests/ImagePreprocessingTests.cs
+++ b/Radiomics.Net.Tests/ImagePreprocessingTests.cs
@@ -1,0 +1,187 @@
+using Radiomics.Net;
+using Radiomics.Net.ImageProcess;
+using Radiomics.Net.Exceptions;
+
+namespace Radiomics.Net.Tests;
+
+public class ImagePreprocessingTests
+{
+    private const double Tolerance = 1e-6;
+
+    [Fact]
+    public void Normalize_ComputesScaledZScores()
+    {
+        var (image, mask, _, parameters) = TestDataFactory.CreateStandardImageData();
+        parameters.NormalizeScale = 1d;
+
+        var normalized = ImagePreprocessing.Normalize(image, mask, parameters);
+
+        var voxels = image.Stack[0];
+        var mean = voxels.Average();
+        var variance = voxels.Select(v => Math.Pow(v - mean, 2)).Average();
+        var stdDev = Math.Sqrt(variance);
+
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                var expected = (image.GetXYZ(x, y, 0) - mean) / stdDev;
+                Assert.Equal(expected, normalized.GetXYZ(x, y, 0), Tolerance);
+            }
+        }
+    }
+
+    [Fact]
+    public void Resample_ExpandsImageUsingNearestNeighbour()
+    {
+        var (image, mask) = TestDataFactory.CreateResampleSource();
+        var parameters = new CaculateParams
+        {
+            Label = 1,
+            Force2D = true,
+            Interpolation2D = 0,
+            MaskPartialVolumeThreshold = 0.5
+        };
+
+        var resampled = ImagePreprocessing.Resample(image, mask, new[] { 1d, 1d, 1d }, parameters);
+
+        Assert.NotNull(resampled[0]);
+        Assert.NotNull(resampled[1]);
+        Assert.Equal(4, resampled[0]!.Width);
+        Assert.Equal(4, resampled[0]!.Height);
+        Assert.All(resampled[1]!.Stack[0], value => Assert.True(value is 0 or 1));
+        Assert.Equal(image.GetXYZ(0, 0, 0), resampled[0]!.GetXYZ(0, 0, 0));
+        Assert.Equal(image.GetXYZ(1, 1, 0), resampled[0]!.GetXYZ(resampled[0]!.Width - 1, resampled[0]!.Height - 1, 0));
+    }
+
+    [Fact]
+    public void Crop_ReturnsBoundingBoxOfRoi()
+    {
+        var (image, mask, _, parameters) = TestDataFactory.CreateStandardImageData();
+        for (int y = 0; y < mask.Height; y++)
+        {
+            for (int x = 0; x < mask.Width; x++)
+            {
+                mask.SetXYZ(x, y, 0, (x >= 1 && y >= 1) ? 1d : 0d);
+            }
+        }
+
+        var cropped = ImagePreprocessing.Crop(image, mask, parameters);
+
+        Assert.Equal(2, cropped[0]!.Width);
+        Assert.Equal(2, cropped[0]!.Height);
+        Assert.Equal(2, cropped[1]!.Width);
+        Assert.Equal(2, cropped[1]!.Height);
+        Assert.Equal(5, cropped[0]!.GetXYZ(0, 0, 0));
+        Assert.Equal(9, cropped[0]!.GetXYZ(1, 1, 0));
+    }
+
+    [Fact]
+    public void OutlierFiltering_RemovesValuesOutsideStandardDeviationRange()
+    {
+        var image = new ImagePlus(3, 1, 1);
+        image.PixelWidth = image.PixelHeight = image.PixelDepth = 1d;
+        image.BitsAllocated = 16;
+        double[] values = { 10, 12, 100 };
+        for (int x = 0; x < values.Length; x++)
+        {
+            image.SetXYZ(x, 0, 0, values[x]);
+        }
+        var mask = TestDataFactory.CreateMaskFor(image);
+        var parameters = new CaculateParams
+        {
+            Label = 1,
+            RangeMin = 1,
+            RangeMax = 1
+        };
+
+        var filteredMask = ImagePreprocessing.OutlierFiltering(image, mask, 1, parameters);
+
+        Assert.Equal(1, filteredMask.GetXYZ(0, 0, 0));
+        Assert.Equal(1, filteredMask.GetXYZ(1, 0, 0));
+        Assert.Equal(0, filteredMask.GetXYZ(2, 0, 0));
+    }
+
+    [Fact]
+    public void RangeFiltering_FiltersOutsideAbsoluteRange()
+    {
+        var image = new ImagePlus(2, 2, 1);
+        image.PixelWidth = image.PixelHeight = image.PixelDepth = 1d;
+        image.BitsAllocated = 16;
+        double[] values = { 1, 2, 3, 4 };
+        for (int y = 0; y < 2; y++)
+        {
+            for (int x = 0; x < 2; x++)
+            {
+                image.SetXYZ(x, y, 0, values[y * 2 + x]);
+            }
+        }
+        var mask = TestDataFactory.CreateMaskFor(image);
+
+        var filtered = ImagePreprocessing.RangeFiltering(image, mask, 1, 3, 2);
+
+        Assert.Equal(0, filtered.GetXYZ(0, 0, 0));
+        Assert.Equal(1, filtered.GetXYZ(1, 0, 0));
+        Assert.Equal(1, filtered.GetXYZ(0, 1, 0));
+        Assert.Equal(0, filtered.GetXYZ(1, 1, 0));
+    }
+
+    [Fact]
+    public void RangeFiltering_InvalidParameters_Throws()
+    {
+        var (image, mask, _, _) = TestDataFactory.CreateStandardImageData();
+        Assert.Throws<CustomException>(() => ImagePreprocessing.RangeFiltering(image, mask, 1, 0, 5));
+    }
+
+    [Fact]
+    public void PreprocessDiscretise_WithFixedBinNumber_ReturnsExpectedBins()
+    {
+        var (image, mask, _, parameters) = TestDataFactory.CreateStandardImageData();
+        parameters.UseFixedBinNumber = true;
+        parameters.NBins = 4;
+
+        var discrete = ImagePreprocessing.PreprocessDiscretise(image, mask, 1, parameters);
+
+        var voxels = Utils.GetVoxels(discrete, mask, 1);
+        Assert.All(voxels, v => Assert.InRange(v, 1, parameters.NBins));
+    }
+
+    [Fact]
+    public void PreprocessDiscretise_WithBinWidth_UpdatesBinCount()
+    {
+        var (image, mask, _, parameters) = TestDataFactory.CreateStandardImageData();
+        parameters.UseFixedBinNumber = false;
+        parameters.BinWidth = 2;
+
+        var discrete = ImagePreprocessing.PreprocessDiscretise(image, mask, 1, parameters);
+
+        var voxels = Utils.GetVoxels(discrete, mask, 1);
+        Assert.All(voxels, v => Assert.True(v >= 1));
+        Assert.Equal(Utils.GetNumOfBinsByMax(discrete, mask, 1), parameters.NBins);
+    }
+
+    [Fact]
+    public void CreateMask_FillsAllVoxelsWithLabel()
+    {
+        var (image, _, _, _) = TestDataFactory.CreateStandardImageData();
+        var mask = ImagePreprocessing.CreateMask(image);
+        Assert.All(mask.Stack[0], value => Assert.Equal(1d, value));
+    }
+
+    [Fact]
+    public void FwtTransform_WithHaarFilterPreservesImage()
+    {
+        var (image, mask, _, parameters) = TestDataFactory.CreateStandardImageData();
+        parameters.WaveFilterName = "haar";
+
+        var filtered = ImagePreprocessing.FwtTransform(image, parameters);
+
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Assert.Equal(image.GetXYZ(x, y, 0), filtered.GetXYZ(x, y, 0), Tolerance);
+            }
+        }
+    }
+}

--- a/Radiomics.Net.Tests/Radiomics.Net.Tests.csproj
+++ b/Radiomics.Net.Tests/Radiomics.Net.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Radiomics.Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Radiomics.Net.Tests/TestDataFactory.cs
+++ b/Radiomics.Net.Tests/TestDataFactory.cs
@@ -1,0 +1,199 @@
+using FellowOakDicom;
+using FellowOakDicom.Imaging;
+using FellowOakDicom.IO.Buffer;
+using Radiomics.Net;
+using Radiomics.Net.ImageProcess;
+
+namespace Radiomics.Net.Tests;
+
+internal static class TestDataFactory
+{
+    public static (ImagePlus image, ImagePlus mask, ImagePlus discrete, CaculateParams parameters) CreateStandardImageData()
+    {
+        var image = new ImagePlus(3, 3, 1)
+        {
+            PixelWidth = 1d,
+            PixelHeight = 1d,
+            PixelDepth = 1d,
+            BitsAllocated = 16
+        };
+
+        var values = new double[]
+        {
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9
+        };
+
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                image.SetXYZ(x, y, 0, values[y * image.Width + x]);
+            }
+        }
+
+        var mask = new ImagePlus(image.Width, image.Height, image.Slice)
+        {
+            PixelWidth = image.PixelWidth,
+            PixelHeight = image.PixelHeight,
+            PixelDepth = image.PixelDepth,
+            BitsAllocated = 16
+        };
+
+        for (int y = 0; y < mask.Height; y++)
+        {
+            for (int x = 0; x < mask.Width; x++)
+            {
+                mask.SetXYZ(x, y, 0, 1d);
+            }
+        }
+
+        var discrete = new ImagePlus(image.Width, image.Height, image.Slice)
+        {
+            PixelWidth = image.PixelWidth,
+            PixelHeight = image.PixelHeight,
+            PixelDepth = image.PixelDepth,
+            BitsAllocated = image.BitsAllocated
+        };
+
+        for (int y = 0; y < discrete.Height; y++)
+        {
+            for (int x = 0; x < discrete.Width; x++)
+            {
+                discrete.SetXYZ(x, y, 0, values[y * discrete.Width + x]);
+            }
+        }
+
+        var parameters = new CaculateParams
+        {
+            Label = 1,
+            UseFixedBinNumber = true,
+            NBins = 9,
+            DensityShift = 0,
+            NormalizeScale = 1,
+            Force2D = true,
+            Interpolation2D = 0,
+            MaskPartialVolumeThreshold = 0.5,
+            GLCMWeightingMethod = "no_weighting"
+        };
+
+        return (image, mask, discrete, parameters);
+    }
+
+    public static ImagePlus CreateMaskFor(ImagePlus source, double label = 1)
+    {
+        var mask = new ImagePlus(source.Width, source.Height, source.Slice)
+        {
+            PixelWidth = source.PixelWidth,
+            PixelHeight = source.PixelHeight,
+            PixelDepth = source.PixelDepth,
+            BitsAllocated = source.BitsAllocated
+        };
+
+        for (int z = 0; z < source.Slice; z++)
+        {
+            for (int y = 0; y < source.Height; y++)
+            {
+                for (int x = 0; x < source.Width; x++)
+                {
+                    mask.SetXYZ(x, y, z, label);
+                }
+            }
+        }
+
+        return mask;
+    }
+
+    public static (ImagePlus image, ImagePlus mask) CreateResampleSource()
+    {
+        var image = new ImagePlus(2, 2, 1)
+        {
+            PixelWidth = 2d,
+            PixelHeight = 2d,
+            PixelDepth = 1d,
+            BitsAllocated = 16
+        };
+
+        var values = new double[] { 1, 2, 3, 4 };
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                image.SetXYZ(x, y, 0, values[y * image.Width + x]);
+            }
+        }
+
+        var mask = CreateMaskFor(image);
+        return (image, mask);
+    }
+
+    public static List<DicomDataset> CreateFeatureCalculatorDicoms(ImagePlus image, ImagePlus mask, CaculateParams parameters, ImagePlus? discrete = null)
+    {
+        var dicomImage = CreateDicomDataset(image);
+        var dicomMask = CreateDicomDataset(mask);
+
+        var preprocessSteps = new List<string> { "Normalize", "Resample", "RangeFilter" };
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.Preprocess, preprocessSteps.ToArray());
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.NormalizeScale, parameters.NormalizeScale);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.ResamplingFactorXYZ, new[] { 1d, 1d, 1d });
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.RangeMax, 100d);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.RangeMin, -100d);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.UseFixedBins, parameters.UseFixedBinNumber ? 1 : 0);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.NBins, parameters.NBins);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.EnableFirstOrder, 1);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.EnableGLCM, 1);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.Interpolation2D, parameters.Interpolation2D);
+        PrivateDicomTag.AddOrUpdate(dicomImage, PrivateDicomTag.MaskPartialVolumeThreshold, parameters.MaskPartialVolumeThreshold);
+
+        return new List<DicomDataset> { dicomImage, dicomMask };
+    }
+
+    private static DicomDataset CreateDicomDataset(ImagePlus source)
+    {
+        var dataset = new DicomDataset
+        {
+            { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage },
+            { DicomTag.SOPInstanceUID, DicomUID.Generate() },
+            { DicomTag.StudyInstanceUID, DicomUID.Generate() },
+            { DicomTag.SeriesInstanceUID, DicomUID.Generate() },
+            { DicomTag.Modality, "OT" },
+            { DicomTag.PatientID, "TEST" },
+            { DicomTag.Rows, (ushort)source.Height },
+            { DicomTag.Columns, (ushort)source.Width },
+            { DicomTag.PixelSpacing, new[] { source.PixelWidth, source.PixelHeight } },
+            { DicomTag.SliceThickness, source.PixelDepth },
+            { DicomTag.BitsAllocated, (ushort)source.BitsAllocated },
+            { DicomTag.BitsStored, (ushort)source.BitsAllocated },
+            { DicomTag.HighBit, (ushort)(source.BitsAllocated - 1) },
+            { DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value },
+            { DicomTag.SamplesPerPixel, (ushort)1 },
+            { DicomTag.PixelRepresentation, (ushort)0 }
+        };
+
+        var pixelData = DicomPixelData.Create(dataset, true);
+        pixelData.SamplesPerPixel = 1;
+        pixelData.PlanarConfiguration = 0;
+        pixelData.BitsStored = (ushort)source.BitsAllocated;
+        pixelData.BitsAllocated = (ushort)source.BitsAllocated;
+        pixelData.HighBit = (ushort)(source.BitsAllocated - 1);
+        pixelData.PixelRepresentation = PixelRepresentation.Unsigned;
+        pixelData.Width = source.Width;
+        pixelData.Height = source.Height;
+
+        var frame = new ushort[source.Width * source.Height];
+        for (int y = 0; y < source.Height; y++)
+        {
+            for (int x = 0; x < source.Width; x++)
+            {
+                frame[y * source.Width + x] = (ushort)Math.Round(source.GetXYZ(x, y, 0));
+            }
+        }
+
+        var bytes = new byte[frame.Length * sizeof(ushort)];
+        Buffer.BlockCopy(frame, 0, bytes, 0, bytes.Length);
+        pixelData.AddFrame(new MemoryByteBuffer(bytes));
+
+        return dataset;
+    }
+}

--- a/RadiomicsNet.sln
+++ b/RadiomicsNet.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.9.34714.143
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radiomics.Net", "Radiomics.Net.csproj", "{AA48FF15-5345-449C-B768-B59E431ECAD7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radiomics.Net.Tests", "Radiomics.Net.Tests\Radiomics.Net.Tests.csproj", "{860EB133-830C-4BFD-9B54-506328DDB833}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{AA48FF15-5345-449C-B768-B59E431ECAD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA48FF15-5345-449C-B768-B59E431ECAD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA48FF15-5345-449C-B768-B59E431ECAD7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{860EB133-830C-4BFD-9B54-506328DDB833}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{860EB133-830C-4BFD-9B54-506328DDB833}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{860EB133-830C-4BFD-9B54-506328DDB833}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{860EB133-830C-4BFD-9B54-506328DDB833}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a dedicated net6.0 xUnit test project that references the Radiomics.Net library
- cover all implemented image preprocessing functions with deterministic unit tests
- validate every first-order and GLCM radiomics feature as well as the overall FeatureCalculator.Calculate flow

## Testing
- `dotnet restore RadiomicsNet.sln` *(fails: unable to reach https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4babb00083208e39afacebbaeacb