### PR TITLE
Add comprehensive xUnit tests for Radiomics.Net

### DIFF
--- a/Radiomics.Net.Tests/FeatureCalculatorTests.cs
+++ b/Radiomics.Net.Tests/FeatureCalculatorTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using FellowOakDicom;
+using FellowOakDicom.IO.Buffer;
+using FellowOakDicom.Imaging;
+using Radiomics.Net.Exceptions;
+using Xunit;
+
+namespace Radiomics.Net.Tests
+{
+    public class FeatureCalculatorTests
+    {
+        private static DicomDataset CreateImageDataset(ushort[] pixelValues, int width, int height)
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian)
+            {
+                { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage },
+                { DicomTag.SOPInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
+                { DicomTag.PatientID, "TEST" },
+                { DicomTag.Rows, (ushort)height },
+                { DicomTag.Columns, (ushort)width },
+                { DicomTag.BitsAllocated, (ushort)16 },
+                { DicomTag.BitsStored, (ushort)16 },
+                { DicomTag.HighBit, (ushort)15 },
+                { DicomTag.PixelRepresentation, (ushort)0 },
+                { DicomTag.SamplesPerPixel, (ushort)1 },
+                { DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value },
+                { DicomTag.PixelSpacing, new double[] { 1.0, 1.0 } },
+                { DicomTag.SliceThickness, 1.0 }
+            };
+
+            var pixelData = DicomPixelData.Create(dataset, true);
+            pixelData.BitsStored = 16;
+            pixelData.BitsAllocated = 16;
+            pixelData.HighBit = 15;
+            pixelData.PixelRepresentation = PixelRepresentation.Unsigned;
+            pixelData.SamplesPerPixel = 1;
+            pixelData.Width = width;
+            pixelData.Height = height;
+            var buffer = new byte[pixelValues.Length * sizeof(ushort)];
+            System.Buffer.BlockCopy(pixelValues, 0, buffer, 0, buffer.Length);
+            pixelData.AddFrame(new MemoryByteBuffer(buffer));
+            return dataset;
+        }
+
+        [Fact]
+        public void Calculate_CompletesFullPipelineAndPopulatesFeatureTags()
+        {
+            ushort[] pixelValues =
+            {
+                1, 2, 3,
+                4, 5, 6,
+                7, 8, 9
+            };
+            var imageDataset = CreateImageDataset(pixelValues, 3, 3);
+            var maskDataset = CreateImageDataset(new ushort[]
+            {
+                1, 1, 1,
+                1, 1, 1,
+                1, 1, 1
+            }, 3, 3);
+
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.Preprocess, new[] { "Normalize", "Resample", "RangeFilter" });
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.NormalizeScale, 1.0);
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.ResamplingFactorXYZ, new[] { 1.0, 1.0, 1.0 });
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.RangeMax, 9.0);
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.RangeMin, 1.0);
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.UseFixedBins, 1);
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.NBins, 2);
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.EnableGLCM, 1);
+            PrivateDicomTag.AddOrUpdate(imageDataset, PrivateDicomTag.EnableFirstOrder, 1);
+
+            var datasets = new List<DicomDataset> { imageDataset, maskDataset };
+            var result = FeatureCalculator.Calclate(datasets);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal((int)Errors.OK, result.ErrorCode);
+
+            Assert.True(imageDataset.TryGetValue<double>(PrivateDicomTag.Mean, 0, out var mean));
+            Assert.False(double.IsNaN(mean));
+            Assert.True(imageDataset.TryGetValue<double>(PrivateDicomTag.MaximumProbability, 0, out var glcmValue));
+            Assert.False(double.IsNaN(glcmValue));
+        }
+    }
+}

--- a/Radiomics.Net.Tests/FirstOrderFeaturesTests.cs
+++ b/Radiomics.Net.Tests/FirstOrderFeaturesTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using Radiomics.Net;
+using Radiomics.Net.Features;
+using Radiomics.Net.ImageProcess;
+using Xunit;
+
+namespace Radiomics.Net.Tests
+{
+    public class FirstOrderFeaturesTests
+    {
+        private static (ImagePlus image, ImagePlus mask) CreateUniformMaskImage()
+        {
+            double[,] values =
+            {
+                { 1, 2, 3 },
+                { 4, 5, 6 },
+                { 7, 8, 9 }
+            };
+            var image = new ImagePlus(3, 3, 1)
+            {
+                PixelWidth = 1,
+                PixelHeight = 1,
+                PixelDepth = 1,
+                BitsAllocated = 16
+            };
+            var mask = new ImagePlus(3, 3, 1)
+            {
+                PixelWidth = 1,
+                PixelHeight = 1,
+                PixelDepth = 1,
+                BitsAllocated = 16
+            };
+            for (int y = 0; y < 3; y++)
+            {
+                for (int x = 0; x < 3; x++)
+                {
+                    image.SetXYZ(x, y, 0, values[y, x]);
+                    mask.SetXYZ(x, y, 0, 1);
+                }
+            }
+            return (image, mask);
+        }
+
+        [Fact]
+        public void Calculate_AllFirstOrderFeatures_MatchExpectedValues()
+        {
+            var (image, mask) = CreateUniformMaskImage();
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                UseFixedBinNumber = true,
+                NBins = 9,
+                DensityShift = 0
+            };
+            var discImg = Utils.Discrete(image, mask, (int)parameters.Label, parameters.NBins);
+            var features = new FirstOrderFeatures(image, mask, discImg, parameters);
+
+            var expected = new Dictionary<FirstOrderFeatureType, double>
+            {
+                [FirstOrderFeatureType.Mean] = 5.0,
+                [FirstOrderFeatureType.Variance] = 6.666666666666667,
+                [FirstOrderFeatureType.Skewness] = 0.0,
+                [FirstOrderFeatureType.Kurtosis] = 1.7699999999999998,
+                [FirstOrderFeatureType.Median] = 5.0,
+                [FirstOrderFeatureType.Minimum] = 1.0,
+                [FirstOrderFeatureType.Percentile10] = 1.0,
+                [FirstOrderFeatureType.Percentile90] = 9.0,
+                [FirstOrderFeatureType.Maximum] = 9.0,
+                [FirstOrderFeatureType.Peak] = 7.0,
+                [FirstOrderFeatureType.Interquartile] = 4.0,
+                [FirstOrderFeatureType.Range] = 8.0,
+                [FirstOrderFeatureType.MeanAbsoluteDeviation] = 2.2222222222222223,
+                [FirstOrderFeatureType.RobustMeanAbsoluteDeviation] = 2.2222222222222223,
+                [FirstOrderFeatureType.Energy] = 285.0,
+                [FirstOrderFeatureType.RootMeanSquared] = 5.627314338711377,
+                [FirstOrderFeatureType.TotalEnergy] = 285.0,
+                [FirstOrderFeatureType.StandardDeviation] = 2.581988897471611,
+                [FirstOrderFeatureType.Entropy] = 3.169925001442312,
+                [FirstOrderFeatureType.Uniformity] = 0.1111111111111111
+            };
+
+            foreach (var featureType in Enum.GetValues<FirstOrderFeatureType>())
+            {
+                double result = features.Calculate(featureType);
+                Assert.True(expected.ContainsKey(featureType));
+                Assert.InRange(result - expected[featureType], -1e-6, 1e-6);
+            }
+        }
+    }
+}

--- a/Radiomics.Net.Tests/GlcmFeaturesTests.cs
+++ b/Radiomics.Net.Tests/GlcmFeaturesTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Radiomics.Net;
+using Radiomics.Net.Features;
+using Radiomics.Net.ImageProcess;
+using Xunit;
+
+namespace Radiomics.Net.Tests
+{
+    public class GlcmFeaturesTests
+    {
+        private static (ImagePlus image, ImagePlus mask) CreateCheckerboardImage()
+        {
+            double[,] values =
+            {
+                { 1, 2, 1 },
+                { 2, 1, 2 },
+                { 1, 2, 1 }
+            };
+            var image = new ImagePlus(3, 3, 1)
+            {
+                PixelWidth = 1,
+                PixelHeight = 1,
+                PixelDepth = 1,
+                BitsAllocated = 16
+            };
+            var mask = new ImagePlus(3, 3, 1)
+            {
+                PixelWidth = 1,
+                PixelHeight = 1,
+                PixelDepth = 1,
+                BitsAllocated = 16
+            };
+            for (int y = 0; y < 3; y++)
+            {
+                for (int x = 0; x < 3; x++)
+                {
+                    image.SetXYZ(x, y, 0, values[y, x]);
+                    mask.SetXYZ(x, y, 0, 1);
+                }
+            }
+            return (image, mask);
+        }
+
+        [Fact]
+        public void Calculate_AllGlcmFeatures_MatchExpectedValues()
+        {
+            var (image, mask) = CreateCheckerboardImage();
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                UseFixedBinNumber = true,
+                NBins = 2,
+                GLCMDelta = 1
+            };
+            var discImg = Utils.Discrete(image, mask, (int)parameters.Label, parameters.NBins);
+            var glcmFeatures = new GLCMFeatures(image, mask, discImg, parameters);
+
+            var expected = new Dictionary<GLCMFeatureType, double>
+            {
+                [GLCMFeatureType.MaximumProbability] = 0.5,
+                [GLCMFeatureType.JointAverage] = 1.5,
+                [GLCMFeatureType.SumSquares] = 0.25,
+                [GLCMFeatureType.JointEntropy] = 1.0,
+                [GLCMFeatureType.JointEnergy] = 0.5,
+                [GLCMFeatureType.DifferenceAverage] = 0.5,
+                [GLCMFeatureType.DifferenceVariance] = 0.0,
+                [GLCMFeatureType.DifferenceEntropy] = 0.0,
+                [GLCMFeatureType.SumAverage] = 3.0,
+                [GLCMFeatureType.SumVariance] = 0.5,
+                [GLCMFeatureType.SumEntropy] = 0.5,
+                [GLCMFeatureType.Contrast] = 0.5,
+                [GLCMFeatureType.InverseDifference] = 0.75,
+                [GLCMFeatureType.NormalizedInverseDifference] = 0.8333333333333333,
+                [GLCMFeatureType.InverseDifferenceMoment] = 0.75,
+                [GLCMFeatureType.NormalizedInverseDifferenceMoment] = 0.9,
+                [GLCMFeatureType.InverseVariance] = 0.5,
+                [GLCMFeatureType.Correlation] = 0.0,
+                [GLCMFeatureType.Autocorrection] = 2.25,
+                [GLCMFeatureType.ClusterTendency] = 0.5,
+                [GLCMFeatureType.ClusterShade] = 0.0,
+                [GLCMFeatureType.ClusterProminence] = 0.5,
+                [GLCMFeatureType.InformationalMeasureOfCorrelation1] = -1.0,
+                [GLCMFeatureType.InformationalMeasureOfCorrelation2] = 0.0,
+                [GLCMFeatureType.MCC] = 1.0
+            };
+
+            foreach (var featureType in Enum.GetValues<GLCMFeatureType>())
+            {
+                double result = glcmFeatures.Calculate(featureType);
+                Assert.True(expected.ContainsKey(featureType));
+                Assert.InRange(result - expected[featureType], -1e-6, 1e-6);
+            }
+        }
+    }
+}

--- a/Radiomics.Net.Tests/ImagePreprocessingTests.cs
+++ b/Radiomics.Net.Tests/ImagePreprocessingTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Linq;
+using Radiomics.Net;
+using Radiomics.Net.ImageProcess;
+using Xunit;
+
+namespace Radiomics.Net.Tests
+{
+    public class ImagePreprocessingTests
+    {
+        private static (ImagePlus image, ImagePlus mask) CreateImageAndMask(double[,] values, int label = 1)
+        {
+            int height = values.GetLength(0);
+            int width = values.GetLength(1);
+            var image = new ImagePlus(width, height, 1)
+            {
+                PixelWidth = 1,
+                PixelHeight = 1,
+                PixelDepth = 1,
+                BitsAllocated = 16
+            };
+            var mask = new ImagePlus(width, height, 1)
+            {
+                PixelWidth = 1,
+                PixelHeight = 1,
+                PixelDepth = 1,
+                BitsAllocated = 16
+            };
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    image.SetXYZ(x, y, 0, values[y, x]);
+                    mask.SetXYZ(x, y, 0, label);
+                }
+            }
+            return (image, mask);
+        }
+
+        private static double[] GetMaskVoxels(ImagePlus image, ImagePlus mask, int label = 1)
+        {
+            return Utils.GetVoxels(image, mask, label);
+        }
+
+        [Fact]
+        public void Normalize_ScalesValuesToZeroMeanAndConfiguredStd()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] { { 1, 2 }, { 3, 4 } });
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                NormalizeScale = 2.0
+            };
+
+            var normalized = ImagePreprocessing.Normalize(image, mask, parameters);
+            var voxels = GetMaskVoxels(normalized, mask);
+            double mean = voxels.Average();
+            double variance = voxels.Select(v => Math.Pow(v - mean, 2)).Average();
+
+            Assert.InRange(mean, -1e-10, 1e-10);
+            Assert.InRange(Math.Sqrt(variance), 2.0 - 1e-10, 2.0 + 1e-10);
+        }
+
+        [Fact]
+        public void Resample_ProducesExpectedDimensionsAndMetadata()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] { { 1, 2 }, { 3, 4 } });
+            image.PixelWidth = 2;
+            image.PixelHeight = 2;
+            mask.PixelWidth = 2;
+            mask.PixelHeight = 2;
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                Force2D = true,
+                Interpolation2D = 0,
+                ResamplingFactorXYZ = new[] { 1.0, 1.0, 1.0 }
+            };
+
+            var resampled = ImagePreprocessing.Resample(image, mask, parameters.ResamplingFactorXYZ, parameters);
+            Assert.NotNull(resampled[0]);
+            Assert.NotNull(resampled[1]);
+            Assert.Equal(4, resampled[0].Width);
+            Assert.Equal(4, resampled[0].Height);
+            Assert.Equal(1.0, resampled[0].PixelWidth);
+            Assert.Equal(1.0, resampled[0].PixelHeight);
+            Assert.Equal(4, resampled[1].Width);
+            Assert.All(resampled[1].Stack[0], v => Assert.True(v == 0 || Math.Abs(v - parameters.Label) < 1e-10));
+        }
+
+        [Fact]
+        public void Crop_ReturnsBoundingBoxAroundLabel()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] {
+                { 0, 1, 2, 3 },
+                { 4, 5, 6, 7 },
+                { 8, 9,10,11 },
+                {12,13,14,15 }
+            });
+            // restrict ROI to center 2x2 region
+            for (int y = 0; y < 4; y++)
+            {
+                for (int x = 0; x < 4; x++)
+                {
+                    mask.SetXYZ(x, y, 0, (x >= 1 && x <= 2 && y >= 1 && y <= 2) ? 1 : 0);
+                }
+            }
+            var parameters = new CaculateParams { Label = 1 };
+
+            var cropped = ImagePreprocessing.Crop(image, mask, parameters);
+            Assert.Equal(2, cropped[0].Width);
+            Assert.Equal(2, cropped[0].Height);
+            double[] expected = { 5, 6, 9, 10 };
+            Assert.Equal(expected, cropped[0].Stack[0]);
+        }
+
+        [Fact]
+        public void OutlierFiltering_RemovesValuesOutsideConfiguredStdRange()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] { { 10, 10 }, { 10, 100 } });
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                RangeMin = 1,
+                RangeMax = 1
+            };
+
+            var filtered = ImagePreprocessing.OutlierFiltering(image, mask, (int)parameters.Label, parameters);
+            Assert.Equal(0, filtered.GetXYZ(1, 1, 0));
+            Assert.Equal(1, filtered.GetXYZ(0, 0, 0));
+        }
+
+        [Fact]
+        public void RangeFiltering_RemovesValuesOutsideRange()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] { { 1, 5 }, { 3, 7 } });
+            var filtered = ImagePreprocessing.RangeFiltering(image, mask, 1, 5, 2);
+            Assert.Equal(0, filtered.GetXYZ(1, 1, 0));
+            Assert.Equal(1, filtered.GetXYZ(0, 0, 0));
+            Assert.Equal(1, filtered.GetXYZ(1, 0, 0));
+        }
+
+        [Fact]
+        public void PreprocessDiscretise_UsesFixedBinNumber()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] { { 1, 2 }, { 3, 4 } });
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                UseFixedBinNumber = true,
+                NBins = 2
+            };
+
+            var discretised = ImagePreprocessing.PreprocessDiscretise(image, mask, (int)parameters.Label, parameters);
+            var voxels = GetMaskVoxels(discretised, mask);
+            Assert.Equal(new[] { 1d, 1d, 2d, 2d }, voxels);
+        }
+
+        [Fact]
+        public void PreprocessDiscretise_UsesBinWidth()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] { { 1, 2 }, { 3, 4 } });
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                UseFixedBinNumber = false,
+                BinWidth = 1
+            };
+
+            var discretised = ImagePreprocessing.PreprocessDiscretise(image, mask, (int)parameters.Label, parameters);
+            var voxels = GetMaskVoxels(discretised, mask);
+            Assert.Equal(new[] { 1d, 2d, 3d, 4d }, voxels);
+            Assert.Equal(4, parameters.NBins);
+        }
+
+        [Fact]
+        public void CreateMask_SetsAllVoxelsToOne()
+        {
+            var (image, _) = CreateImageAndMask(new double[,] { { 0, 2 }, { 3, 4 } });
+            var mask = ImagePreprocessing.CreateMask(image);
+            Assert.All(mask.Stack[0], v => Assert.Equal(1d, v));
+        }
+
+        [Fact]
+        public void FwtTransform_PreservesSignalAfterForwardAndInverse()
+        {
+            var (image, mask) = CreateImageAndMask(new double[,] { { 1, 2 }, { 3, 4 } });
+            var parameters = new CaculateParams
+            {
+                Label = 1,
+                WaveFilterName = "haar"
+            };
+
+            var transformed = ImagePreprocessing.FwtTransform(image, parameters);
+            var originalVoxels = GetMaskVoxels(image, mask);
+            var transformedVoxels = GetMaskVoxels(transformed, mask);
+            for (int i = 0; i < originalVoxels.Length; i++)
+            {
+                Assert.InRange(transformedVoxels[i] - originalVoxels[i], -1e-6, 1e-6);
+            }
+        }
+    }
+}

--- a/Radiomics.Net.Tests/Radiomics.Net.Tests.csproj
+++ b/Radiomics.Net.Tests/Radiomics.Net.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Radiomics.Net.csproj" />
+  </ItemGroup>
+</Project>

--- a/RadiomicsNet.sln
+++ b/RadiomicsNet.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.9.34714.143
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radiomics.Net", "Radiomics.Net.csproj", "{AA48FF15-5345-449C-B768-B59E431ECAD7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Radiomics.Net.Tests", "Radiomics.Net.Tests\\Radiomics.Net.Tests.csproj", "{5D428564-FF9E-472C-A95A-44E8DFD406F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AA48FF15-5345-449C-B768-B59E431ECAD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AA48FF15-5345-449C-B768-B59E431ECAD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AA48FF15-5345-449C-B768-B59E431ECAD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AA48FF15-5345-449C-B768-B59E431ECAD7}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{AA48FF15-5345-449C-B768-B59E431ECAD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{AA48FF15-5345-449C-B768-B59E431ECAD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{AA48FF15-5345-449C-B768-B59E431ECAD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{AA48FF15-5345-449C-B768-B59E431ECAD7}.Release|Any CPU.Build.0 = Release|Any CPU
+{5D428564-FF9E-472C-A95A-44E8DFD406F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{5D428564-FF9E-472C-A95A-44E8DFD406F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{5D428564-FF9E-472C-A95A-44E8DFD406F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{5D428564-FF9E-472C-A95A-44E8DFD406F2}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a dedicated xUnit test project targeting .NET 6
- cover image preprocessing, first-order, and GLCM feature calculations with deterministic test data
- verify the FeatureCalculator pipeline populates expected DICOM private tags

## Testing
- `dotnet test RadiomicsNet.sln` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4babb00083208e39afacebbaeacb